### PR TITLE
The syncer has beed updated to check the PersistentVolumeReclaimPolic…

### DIFF
--- a/pkg/controllers/resources/persistentvolumes/syncer.go
+++ b/pkg/controllers/resources/persistentvolumes/syncer.go
@@ -250,6 +250,8 @@ func (s *persistentVolumeSyncer) shouldSync(ctx context.Context, pObj *corev1.Pe
 			return false, nil, err
 		} else if translate.IsManagedCluster(s.targetNamespace, pObj) {
 			return true, nil, nil
+		} else if kerrors.IsNotFound(err) {
+			return pObj.Spec.PersistentVolumeReclaimPolicy == corev1.PersistentVolumeReclaimRetain, nil, nil
 		}
 
 		return false, nil, nil

--- a/pkg/controllers/resources/persistentvolumes/syncer_test.go
+++ b/pkg/controllers/resources/persistentvolumes/syncer_test.go
@@ -1,10 +1,11 @@
 package persistentvolumes
 
 import (
+	"testing"
+
 	synccontext "github.com/loft-sh/vcluster/pkg/controllers/syncer/context"
 	"gotest.tools/assert"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"testing"
 
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -108,9 +109,10 @@ func TestSync(t *testing.T) {
 		Spec: corev1.PersistentVolumeSpec{
 			PersistentVolumeReclaimPolicy: corev1.PersistentVolumeReclaimRetain,
 			ClaimRef: &corev1.ObjectReference{
-				Name:      "deletedPVC",
+				Name:      "retainPVC-x-test-x-suffix",
 				Namespace: "test",
 			},
+			StorageClassName: "vcluster-retainSC-x-test-x-suffix",
 		},
 		Status: corev1.PersistentVolumeStatus{
 			Phase: corev1.VolumeReleased,
@@ -121,9 +123,10 @@ func TestSync(t *testing.T) {
 		Spec: corev1.PersistentVolumeSpec{
 			PersistentVolumeReclaimPolicy: corev1.PersistentVolumeReclaimRetain,
 			ClaimRef: &corev1.ObjectReference{
-				Name:      "deletedPVC",
+				Name:      "retainPVC",
 				Namespace: "test",
 			},
+			StorageClassName: "retainSC",
 		},
 		Status: corev1.PersistentVolumeStatus{
 			Phase: corev1.VolumeBound,
@@ -134,9 +137,10 @@ func TestSync(t *testing.T) {
 		Spec: corev1.PersistentVolumeSpec{
 			PersistentVolumeReclaimPolicy: corev1.PersistentVolumeReclaimRetain,
 			ClaimRef: &corev1.ObjectReference{
-				Name:      "deletedPVC",
+				Name:      "retainPVC",
 				Namespace: "test",
 			},
+			StorageClassName: "retainSC",
 		},
 		Status: corev1.PersistentVolumeStatus{
 			Phase: corev1.VolumeReleased,

--- a/pkg/controllers/resources/persistentvolumes/syncer_test.go
+++ b/pkg/controllers/resources/persistentvolumes/syncer_test.go
@@ -103,6 +103,71 @@ func TestSync(t *testing.T) {
 			Message: "someMessage",
 		},
 	}
+	backwardRetainPPv := &corev1.PersistentVolume{
+		ObjectMeta: basePvObjectMeta,
+		Spec: corev1.PersistentVolumeSpec{
+			PersistentVolumeReclaimPolicy: corev1.PersistentVolumeReclaimRetain,
+			ClaimRef: &corev1.ObjectReference{
+				Name:      "deletedPVC",
+				Namespace: "test",
+			},
+		},
+		Status: corev1.PersistentVolumeStatus{
+			Phase: corev1.VolumeReleased,
+		},
+	}
+	backwardRetainInitialVPv := &corev1.PersistentVolume{
+		ObjectMeta: basePvObjectMeta,
+		Spec: corev1.PersistentVolumeSpec{
+			PersistentVolumeReclaimPolicy: corev1.PersistentVolumeReclaimRetain,
+			ClaimRef: &corev1.ObjectReference{
+				Name:      "deletedPVC",
+				Namespace: "test",
+			},
+		},
+		Status: corev1.PersistentVolumeStatus{
+			Phase: corev1.VolumeBound,
+		},
+	}
+	backwardRetainedVPv := &corev1.PersistentVolume{
+		ObjectMeta: basePvObjectMeta,
+		Spec: corev1.PersistentVolumeSpec{
+			PersistentVolumeReclaimPolicy: corev1.PersistentVolumeReclaimRetain,
+			ClaimRef: &corev1.ObjectReference{
+				Name:      "deletedPVC",
+				Namespace: "test",
+			},
+		},
+		Status: corev1.PersistentVolumeStatus{
+			Phase: corev1.VolumeReleased,
+		},
+	}
+	backwardDeletePPv := &corev1.PersistentVolume{
+		ObjectMeta: basePvObjectMeta,
+		Spec: corev1.PersistentVolumeSpec{
+			PersistentVolumeReclaimPolicy: corev1.PersistentVolumeReclaimDelete,
+			ClaimRef: &corev1.ObjectReference{
+				Name:      "deletedPVC",
+				Namespace: "test",
+			},
+		},
+		Status: corev1.PersistentVolumeStatus{
+			Phase: corev1.VolumeBound,
+		},
+	}
+	backwardDeleteVPv := &corev1.PersistentVolume{
+		ObjectMeta: basePvObjectMeta,
+		Spec: corev1.PersistentVolumeSpec{
+			PersistentVolumeReclaimPolicy: corev1.PersistentVolumeReclaimDelete,
+			ClaimRef: &corev1.ObjectReference{
+				Name:      "deletedPVC",
+				Namespace: "test",
+			},
+		},
+		Status: corev1.PersistentVolumeStatus{
+			Phase: corev1.VolumeBound,
+		},
+	}
 
 	generictesting.RunTests(t, []*generictesting.SyncTest{
 		{
@@ -288,6 +353,42 @@ func TestSync(t *testing.T) {
 				assert.NilError(t, err)
 
 				_, err = syncer.Sync(syncContext, pPv, vPv)
+				assert.NilError(t, err)
+			},
+		},
+		{
+			Name:                 "Retain PV and update PV Status",
+			InitialVirtualState:  []runtime.Object{backwardRetainInitialVPv},
+			InitialPhysicalState: []runtime.Object{backwardRetainPPv},
+			ExpectedVirtualState: map[schema.GroupVersionKind][]runtime.Object{
+				corev1.SchemeGroupVersion.WithKind("PersistentVolume"): {backwardRetainedVPv},
+			},
+			ExpectedPhysicalState: map[schema.GroupVersionKind][]runtime.Object{
+				corev1.SchemeGroupVersion.WithKind("PersistentVolume"): {backwardRetainPPv},
+			},
+			Sync: func(ctx *synccontext.RegisterContext) {
+				syncContext, syncer := newFakeSyncer(t, ctx)
+				backwardRetainPPv := backwardRetainPPv.DeepCopy()
+				backwardRetainInitialVPv := backwardRetainInitialVPv.DeepCopy()
+				_, err := syncer.Sync(syncContext, backwardRetainPPv, backwardRetainInitialVPv)
+				assert.NilError(t, err)
+			},
+		},
+		{
+			Name:                 "Delete PV",
+			InitialVirtualState:  []runtime.Object{backwardDeleteVPv},
+			InitialPhysicalState: []runtime.Object{backwardDeletePPv},
+			ExpectedVirtualState: map[schema.GroupVersionKind][]runtime.Object{
+				corev1.SchemeGroupVersion.WithKind("PersistentVolume"): {},
+			},
+			ExpectedPhysicalState: map[schema.GroupVersionKind][]runtime.Object{
+				corev1.SchemeGroupVersion.WithKind("PersistentVolume"): {backwardDeletePPv},
+			},
+			Sync: func(ctx *synccontext.RegisterContext) {
+				syncContext, syncer := newFakeSyncer(t, ctx)
+				backwardDeletePPv := backwardDeletePPv.DeepCopy()
+				backwardDeleteVPv := backwardDeleteVPv.DeepCopy()
+				_, err := syncer.Sync(syncContext, backwardDeletePPv, backwardDeleteVPv)
 				assert.NilError(t, err)
 			},
 		},

--- a/pkg/controllers/resources/persistentvolumes/translate.go
+++ b/pkg/controllers/resources/persistentvolumes/translate.go
@@ -51,6 +51,7 @@ func (s *persistentVolumeSyncer) translateUpdateBackwards(ctx *synccontext.SyncC
 
 	// build virtual persistent volume
 	translatedSpec := *pPv.Spec.DeepCopy()
+	storageClassCreatedOnVirtual, claimRefCreatedOnVirtual := false, false
 	if vPvc != nil {
 		translatedSpec.ClaimRef.ResourceVersion = vPvc.ResourceVersion
 		translatedSpec.ClaimRef.UID = vPvc.UID
@@ -59,18 +60,27 @@ func (s *persistentVolumeSyncer) translateUpdateBackwards(ctx *synccontext.SyncC
 		if vPvc.Spec.StorageClassName != nil {
 			translatedSpec.StorageClassName = *vPvc.Spec.StorageClassName
 		}
+		// when the PVC gets deleted
+	} else {
+		// check if SC was created on virtual
+		storageClassPhysicalName := translateStorageClass(ctx.TargetNamespace, vPv.Spec.StorageClassName)
+		storageClassCreatedOnVirtual = equality.Semantic.DeepEqual(storageClassPhysicalName, translatedSpec.StorageClassName)
+
+		// check if claim was created on virtual
+		claimRefPhysicalName := translate.PhysicalName(vPv.Spec.ClaimRef.Name, vPv.Spec.ClaimRef.Namespace)
+		claimRefCreatedOnVirtual = equality.Semantic.DeepEqual(claimRefPhysicalName, translatedSpec.ClaimRef.Name)
 	}
 
-	// check storage class
+	// check storage class. Do not copy the name, if it was created on virtual.
 	if !translate.IsManagedCluster(ctx.TargetNamespace, pPv) {
-		if !equality.Semantic.DeepEqual(vPv.Spec.StorageClassName, translatedSpec.StorageClassName) {
+		if !equality.Semantic.DeepEqual(vPv.Spec.StorageClassName, translatedSpec.StorageClassName) && !storageClassCreatedOnVirtual {
 			updated = newIfNil(updated, vPv)
 			updated.Spec.StorageClassName = translatedSpec.StorageClassName
 		}
 	}
 
-	// check claim ref
-	if !equality.Semantic.DeepEqual(vPv.Spec.ClaimRef, translatedSpec.ClaimRef) {
+	// check claim ref. Do not copy, if it was created on virtual.
+	if !equality.Semantic.DeepEqual(vPv.Spec.ClaimRef, translatedSpec.ClaimRef) && !claimRefCreatedOnVirtual {
 		updated = newIfNil(updated, vPv)
 		updated.Spec.ClaimRef = translatedSpec.ClaimRef
 	}


### PR DESCRIPTION
The syncer has been updated to check the PersistentVolumeReclaimPolicy before deleting the PV. If the PersistentVolumeReclaimPolicy is not 'Delete', the PV is not deleted and its status is updated. Before this code change, irrespective of the PersistentVolumeReclaimPolicy, the PV was getting deleted.

The syncer_test has been modify with the following changes:
1. Added a default PersistentVolumeReclaimPolicy field to the existing test case objects, since now the syncer checks for the PersistentVolumeReclaimPolicy field to take further action. 
2. Added a new test case for updating the virtual PV status with the new status from the physical PV status.

Issue 1 & 2 is fixed with this code. This fix will work when SC (based on dynamic provisioning), PVC & POD are created on the VC. 