### PR TITLE
Allow syncer to omit taints that have enforced tolerations

### DIFF
--- a/pkg/controllers/resources/nodes/translate.go
+++ b/pkg/controllers/resources/nodes/translate.go
@@ -300,10 +300,6 @@ func (s *nodeSyncer) filterOutTaintsMatchingTolerations(taints []corev1.Taint) [
 nextTaint:
 	for _, taint := range taints {
 		for _, tol := range s.enforcedTolerations {
-			// Refer Kubernetes Documentation for Taints & Tolerations
-			// for rules about toleration matching taints
-			// https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
-
 			// Special case
 			// An empty key with operator Exists matches all keys,
 			// values and effects which means this will tolerate everything.

--- a/pkg/controllers/resources/nodes/translate.go
+++ b/pkg/controllers/resources/nodes/translate.go
@@ -91,6 +91,11 @@ func (s *nodeSyncer) translateUpdateBackwards(pNode *corev1.Node, vNode *corev1.
 		labels, annotations = translate.ApplyMetadata(pNode.Annotations, vNode.Annotations, pNode.Labels, vNode.Labels)
 	}
 
+	// Omit those taints for which the vcluster has enforced tolerations defined
+	if len(s.enforcedTolerations) > 0 && len(translatedSpec.Taints) > 0 {
+		translatedSpec.Taints = s.filterOutTaintsMatchingTolerations(translatedSpec.Taints)
+	}
+
 	if !equality.Semantic.DeepEqual(vNode.Spec, *translatedSpec) {
 		updated = newIfNil(updated, vNode)
 		updated.Spec = *translatedSpec
@@ -287,4 +292,37 @@ func mergeResources(a corev1.ResourceList, b corev1.ResourceList) corev1.Resourc
 		return nil
 	}
 	return merged
+}
+
+func (s *nodeSyncer) filterOutTaintsMatchingTolerations(taints []corev1.Taint) []corev1.Taint {
+	var filtered []corev1.Taint
+
+nextTaint:
+	for _, taint := range taints {
+		for _, tol := range s.enforcedTolerations {
+			// Refer Kubernetes Documentation for Taints & Tolerations
+			// for rules about toleration matching taints
+			// https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+
+			// Special case
+			// An empty key with operator Exists matches all keys,
+			// values and effects which means this will tolerate everything.
+			if tol.Key == "" && tol.Operator == corev1.TolerationOpExists {
+				return nil
+			}
+
+			if taint.Key == tol.Key && (taint.Effect == tol.Effect || tol.Effect == corev1.TaintEffect("")) {
+				if tol.Operator == corev1.TolerationOpExists ||
+					(tol.Operator == corev1.TolerationOpEqual && taint.Value == tol.Value) {
+					// taint matched the current toleration, skip to next taint
+					continue nextTaint
+				}
+			}
+		}
+
+		// taint did not match any enforced toleration, keep it
+		filtered = append(filtered, taint)
+	}
+
+	return filtered
 }


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bug fix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #


**Issue Root Cause**
Tolerations are enforced on a pod level. It works nicely for Deployment and StatefulSet kinds, as they create the required number of pods in `Pending` state. These pods are then available to be scheduled on eligible nodes by K8s scheduler.
The vcluster syncer syncs these pods to host cluster and applies the tolerations specified in `--enforce-toleration` syncer flag to the pod spec of the pods in the host cluster. These pods thus are able to tolerate the tainted nodes and get scheduled successfully by the default kube-scheduler.

However, DaemonSet pods are created and scheduled by the DaemonSet controller instead of the default kube-scheduler. It looks at all the eligible nodes for scheduling & only creates pods for those nodes. Hence, if the DaemonSet controller is unable to find the correct number of eligible nodes it will not create expected number of pods. 

**Solution**
As suggested by Oleg in the issue, this PR updates the Node syncer to omit the taints tolerated by the vcluster. Since the vcluster nodes lack the taints defined with `--enfore-toleration`, DaemonSet controller can correctly identify the eligible nodes & create pods accordingly. Once the pods get created in vcluster, the syncer can now apply the enforeced tolerations while syncing them with the host cluster.