### PR TITLE
Retain the PersistentVolume when the PersistentVolumeReclaimPolicy is 'Retain'.

### DIFF
--- a/pkg/controllers/resources/persistentvolumes/syncer.go
+++ b/pkg/controllers/resources/persistentvolumes/syncer.go
@@ -251,8 +251,7 @@ func (s *persistentVolumeSyncer) shouldSync(ctx context.Context, pObj *corev1.Pe
 		} else if translate.IsManagedCluster(s.targetNamespace, pObj) {
 			return true, nil, nil
 		}
-
-		return false, nil, nil
+		return pObj.Spec.PersistentVolumeReclaimPolicy == corev1.PersistentVolumeReclaimRetain, nil, nil
 	}
 
 	return true, vPvc, nil


### PR DESCRIPTION
What issue type does this pull request address? (keep at least one, remove the others)
/kind bugfix

What does this pull request do? Which issues does it resolve? (use resolves #<issue_number> if possible)
It resolves a part of the defect. Enable SC & PV sync from virtual cluster to host cluster. When the SC (ReclaimPolicy is Retain), PVC & Pod were created on the VC and the PV was dynamically provisioned, a delete on the POD and then PVC, used to delete the PV as well. This fix now retains the PV, when the ReclaimPolicy is set to Retain.

Please provide a short message that should be published in the vcluster release notes
Fixed an issue where a dynamically provisioned PersistentVolume was deleted, when the ReclaimPolicy on the StorageClass was Retain. This fix works when the StorageClass & PersistentVolume sync from virtual cluster to host cluster are enabled and StorageClass, PersistentVolumeClaim & POD are created & deleted in the Virtual Cluster.

Issue Root Cause
A check for the PersistentVolumeReclaimPolicy of the PersistentVolume was missing and the PersistentVolumes were always deleted when the corresponding PersistentVolumeClaim was deleted.

Solution
A check for the PersistentVolumeReclaimPolicy of the PersistentVolume has been introduced in the syncer as part of the fix. If the PersistentVolumeReclaimPolicy is Retain, then the PersistentVolume is not deleted. Now, when the persistent volume is retained, the names of the Claim and StorageClass was displayed from the Physical PersistentVolume, the translateUpdateBackwards function in the translator has been modified to get the names from the Virtual PersistentVolume, in case the PersistentVolumeClaim no longer exists. This fix has been tested on AWS & GCP.

Which issues it does not resolve?
Scenario b & c of the defect.