### PR TITLE
Deletes PVs which are either statically created or the dynamically provisioned PV which is Released and the Reclaim policy is Retain.

### DIFF
--- a/pkg/controllers/resources/persistentvolumes/syncer.go
+++ b/pkg/controllers/resources/persistentvolumes/syncer.go
@@ -129,10 +129,17 @@ func (s *persistentVolumeSyncer) Sync(ctx *synccontext.SyncContext, pObj client.
 
 	// check if virtual persistent volume is deleted
 	if vPersistentVolume.GetDeletionTimestamp() != nil && len(vPersistentVolume.GetFinalizers()) > 0 {
-		//delete the finalizer, so that the object can be deleted
-		vPersistentVolume.SetFinalizers(nil)
-		ctx.Log.Infof("remove virtual persistent volume %s finalizers, because virtual persistent volume is terminating", vPersistentVolume.GetName())
-		return ctrl.Result{}, ctx.VirtualClient.Update(ctx.Context, vPersistentVolume)
+		if vPersistentVolume.Spec.ClaimRef != nil && vPersistentVolume.Spec.PersistentVolumeReclaimPolicy == corev1.PersistentVolumeReclaimDelete {
+			// executes when dynamically provisioned PV with a delete reclaim policy gets deleted
+			// it also releases the cloud provider volume.
+			vPersistentVolume.SetFinalizers(nil)
+			ctx.Log.Infof("remove virtual persistent volume %s finalizers, because virtual persistent volume is terminating", vPersistentVolume.GetName())
+			return ctrl.Result{}, ctx.VirtualClient.Update(ctx.Context, vPersistentVolume)
+		} else {
+			// executes when a Retained PV in Released status is manually deleted and when statically provisioned PVs are deleted
+			ctx.Log.Infof("remove physical persistent volume %s, because virtual persistent volume is deleted", pPersistentVolume.GetName())
+			return ctrl.Result{}, ctx.PhysicalClient.Delete(ctx.Context, pPersistentVolume)
+		}
 	}
 
 	// check if the persistent volume should get synced
@@ -215,6 +222,10 @@ func (s *persistentVolumeSyncer) SyncUp(ctx *synccontext.SyncContext, pObj clien
 	} else if translate.IsManagedCluster(ctx.TargetNamespace, pObj) {
 		ctx.Log.Infof("delete physical persistent volume %s, because it is not needed anymore", pPersistentVolume.Name)
 		return syncer.DeleteObject(ctx, pObj)
+	} else if pPersistentVolume.GetDeletionTimestamp() != nil {
+		// executes after the sync when a Retained PV in Released status is manually deleted
+		ctx.Log.Infof("deleting physical persistent volume %s", pPersistentVolume.Name)
+		return ctrl.Result{}, nil
 	} else if sync {
 		// create the persistent volume
 		vObj := s.translateBackwards(pPersistentVolume, vPvc)


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
It extends the PR 8 which was a fix for the "issue 2". This fix now handles deletion of the PV which was statically created. It even handles manual deletion of a dynamically provisioned PV which is in the Released status and the reclaim policy is Retain.

**Please provide a short message that should be published in the vcluster release notes**
Fixed issues where a the persistent volume is deleted which was either statically created or a dynamically provisioned PV which is in the Released status and the reclaim policy is Retain.