### PR TITLE
Provide service creation rights to the service account for correct service-cidr retrieval on vcluster-eks chart

### DIFF
--- a/charts/eks/templates/pre-install-hook-job-role.yaml
+++ b/charts/eks/templates/pre-install-hook-job-role.yaml
@@ -10,6 +10,6 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded    
 rules:
   - apiGroups: [""]
-    resources: ["secrets", "configmaps"]
+    resources: ["secrets", "configmaps","services"]
     verbs: ["create", "get", "list"]
 {{- end }}


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
It provides service creation rights to the service-account which allows the init container to get the correct CIDR. Currently, the user cannot create service resource in API group which is required for the init job that creates the service-cidr-configmap.

**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where the service-account was provided with the service resource creation rights to retrieve the correct CIDR on vcluster-eks.

