### PR TITLE
Releases the cloud provider volume when a dynamically provisioned PV with a reclaim policy of 'Delete', is deleted.

### DIFF
--- a/pkg/controllers/resources/persistentvolumes/syncer.go
+++ b/pkg/controllers/resources/persistentvolumes/syncer.go
@@ -130,13 +130,16 @@ func (s *persistentVolumeSyncer) Sync(ctx *synccontext.SyncContext, pObj client.
 	// check if objects are getting deleted
 	if vObj.GetDeletionTimestamp() != nil {
 		if pObj.GetDeletionTimestamp() == nil {
-			ctx.Log.Infof("delete physical persistent volume %s, because virtual persistent volume is terminating", pObj.GetName())
-			err := ctx.PhysicalClient.Delete(ctx.Context, pObj)
-			if err != nil {
-				return ctrl.Result{}, err
+			// check if the PV is dynamically provisioned and the reclaim policy is Delete
+			if !(vPersistentVolume.Spec.ClaimRef != nil && vPersistentVolume.Spec.PersistentVolumeReclaimPolicy == corev1.PersistentVolumeReclaimDelete) {
+				ctx.Log.Infof("delete physical persistent volume %s, because virtual persistent volume is deleted", pObj.GetName())
+				err := ctx.PhysicalClient.Delete(ctx.Context, pObj)
+				if err != nil {
+					return ctrl.Result{}, err
+				}
 			}
 		}
-
+		ctx.Log.Infof("requeue because virtual persistent volume %s, has to be deleted", vObj.GetName())
 		return ctrl.Result{RequeueAfter: time.Second}, nil
 	}
 


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
This fixes the "issue 2" of the defect. With this fix, when the PV is dynamically provisioned and its reclaim policy is Delete, we now wait for the physical PV to be deleted and in-turn the CSI to delete the cloud provider volume naturally. Once the physical PV gets deleted, the existing code takes care of clearing the finalizers on the virtual PV and the same gets deleted eventually. 

**Please provide a short message that should be published in the vcluster release notes**
Releases the cloud provider volume when a dynamically provisioned PV with a reclaim policy of 'Delete', is deleted.