### PR TITLE
Vcluster delete --ignore-not-found

### DIFF
--- a/cmd/vclusterctl/cmd/find/find.go
+++ b/cmd/vclusterctl/cmd/find/find.go
@@ -3,9 +3,10 @@ package find
 import (
 	"context"
 	"fmt"
-	"github.com/loft-sh/vcluster/cmd/vclusterctl/log"
 	"strings"
 	"time"
+
+	"github.com/loft-sh/vcluster/cmd/vclusterctl/log"
 
 	"github.com/loft-sh/vcluster/pkg/constants"
 	"github.com/pkg/errors"
@@ -57,12 +58,20 @@ func GetVCluster(context, name, namespace string) (*VCluster, error) {
 	if err != nil {
 		return nil, err
 	} else if len(vclusters) == 0 {
-		return nil, fmt.Errorf("couldn't find vcluster %s", name)
+		return nil, &ErrorNotFoundVcluster{Name: name}
 	} else if len(vclusters) == 1 {
 		return &vclusters[0], nil
 	}
 
 	return nil, fmt.Errorf("multiple vclusters with name %s found, please specify a namespace via -n", name)
+}
+
+type ErrorNotFoundVcluster struct {
+	Name string
+}
+
+func (e *ErrorNotFoundVcluster) Error() string {
+	return fmt.Sprintf("couldn't find vcluster %s", e.Name)
 }
 
 func ListVClusters(context, name, namespace string) ([]VCluster, error) {

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -220,13 +220,21 @@ func (c *client) Delete(name, namespace string) error {
 	output, err := exec.Command(c.helmPath, args...).CombinedOutput()
 	if err != nil {
 		if strings.Contains(string(output), "release: not found") {
-			return fmt.Errorf("release '%s' was not found in namespace '%s'", name, namespace)
+			return &ErrorNotFoundHelm{Name: name, Namespace: namespace}
 		}
-
 		return fmt.Errorf("error executing helm delete: %s", string(output))
 	}
 
 	return nil
+}
+
+type ErrorNotFoundHelm struct {
+	Name      string
+	Namespace string
+}
+
+func (e *ErrorNotFoundHelm) Error() string {
+	return fmt.Sprintf("release '%s' was not found in namespace '%s'", e.Name, e.Namespace)
 }
 
 func (c *client) Exists(name, namespace string) (bool, error) {


### PR DESCRIPTION
Added a new flag --ignore-not-found, which ignores the resource if the flag is mentioned instead of throwing and error and exiting

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind feature

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves 771


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster ...
Added a new flag `--ignore-not-found` that will not exit with an error code, in case if the vlcuster to be deleted does not exist

**What else do we need to know?** 
