### PR TITLE
Disable node/proxy functionality in Isolated mode

### DIFF
--- a/charts/eks/templates/rbac/clusterrole.yaml
+++ b/charts/eks/templates/rbac/clusterrole.yaml
@@ -18,7 +18,9 @@ rules:
     resources: ["nodes", "nodes/status"]
     verbs: ["get", "watch", "list"]
   - apiGroups: [""]
-    resources: ["pods", "nodes/proxy", "nodes/metrics", "nodes/stats"]
+    resources: [ "pods",{{- if .Values.isolation.enabled }}
+      {{- if .Values.isolation.nodeProxyPermission.enabled}} "node/proxy",{{- end}}
+      {{- else}} "node/proxy",{{- end }} "nodes/metrics", "nodes/stats"]
     verbs: ["get", "watch", "list"]
   {{- end }}
   {{- if or (and .Values.sync.nodes.enabled .Values.sync.nodes.syncNodeChanges) .Values.rbac.clusterRole.create }}

--- a/charts/eks/templates/rbac/clusterrole.yaml
+++ b/charts/eks/templates/rbac/clusterrole.yaml
@@ -18,9 +18,12 @@ rules:
     resources: ["nodes", "nodes/status"]
     verbs: ["get", "watch", "list"]
   - apiGroups: [""]
-    resources: [ "pods",{{- if .Values.isolation.enabled }}
-      {{- if .Values.isolation.nodeProxyPermission.enabled}} "node/proxy",{{- end}}
-      {{- else}} "node/proxy",{{- end }} "nodes/metrics", "nodes/stats"]
+    resources: [ "pods", "nodes/metrics", "nodes/stats"]
+    verbs: ["get", "watch", "list"]
+  {{- end }}
+  {{- if and (or .Values.sync.nodes.enabled .Values.rbac.clusterRole.create) (or (not .Values.isolation.enabled) (and .Values.isolation.nodeProxyPermission.enabled .Values.isolation.enabled)) }}
+  - apiGroups: [""]
+    resources: ["nodes/proxy"]
     verbs: ["get", "watch", "list"]
   {{- end }}
   {{- if or (and .Values.sync.nodes.enabled .Values.sync.nodes.syncNodeChanges) .Values.rbac.clusterRole.create }}

--- a/charts/eks/values.yaml
+++ b/charts/eks/values.yaml
@@ -380,6 +380,11 @@ isolation:
 
   podSecurityStandard: baseline
 
+  # If enabled will add node/proxy permission to the cluster role
+  # in isolation mode
+  nodeProxyPermission:
+    enabled: false
+
   resourceQuota:
     enabled: true
     quota:

--- a/charts/k0s/templates/rbac/clusterrole.yaml
+++ b/charts/k0s/templates/rbac/clusterrole.yaml
@@ -18,9 +18,12 @@ rules:
     resources: ["nodes", "nodes/status"]
     verbs: ["get", "watch", "list"]
   - apiGroups: [""]
-    resources: resources: [ "pods",{{- if .Values.isolation.enabled }}
-      {{- if .Values.isolation.nodeProxyPermission.enabled}} "node/proxy",{{- end}}
-      {{- else}} "node/proxy",{{- end }} "nodes/metrics", "nodes/stats"]
+    resources: [ "pods", "nodes/metrics", "nodes/stats"]
+    verbs: ["get", "watch", "list"]
+  {{- end }}
+  {{- if and (or .Values.sync.nodes.enabled .Values.rbac.clusterRole.create) (or (not .Values.isolation.enabled) (and .Values.isolation.nodeProxyPermission.enabled .Values.isolation.enabled)) }}
+  - apiGroups: [""]
+    resources: ["nodes/proxy"]
     verbs: ["get", "watch", "list"]
   {{- end }}
   {{- if or (and .Values.sync.nodes.enabled .Values.sync.nodes.syncNodeChanges) .Values.rbac.clusterRole.create }}

--- a/charts/k0s/templates/rbac/clusterrole.yaml
+++ b/charts/k0s/templates/rbac/clusterrole.yaml
@@ -18,7 +18,9 @@ rules:
     resources: ["nodes", "nodes/status"]
     verbs: ["get", "watch", "list"]
   - apiGroups: [""]
-    resources: ["pods", "nodes/proxy", "nodes/metrics", "nodes/stats"]
+    resources: resources: [ "pods",{{- if .Values.isolation.enabled }}
+      {{- if .Values.isolation.nodeProxyPermission.enabled}} "node/proxy",{{- end}}
+      {{- else}} "node/proxy",{{- end }} "nodes/metrics", "nodes/stats"]
     verbs: ["get", "watch", "list"]
   {{- end }}
   {{- if or (and .Values.sync.nodes.enabled .Values.sync.nodes.syncNodeChanges) .Values.rbac.clusterRole.create }}

--- a/charts/k0s/values.yaml
+++ b/charts/k0s/values.yaml
@@ -338,6 +338,11 @@ isolation:
 
   podSecurityStandard: baseline
 
+  # If enabled will add node/proxy permission to the cluster role
+  # in isolation mode
+  nodeProxyPermission:
+    enabled: false
+
   resourceQuota:
     enabled: true
     quota:

--- a/charts/k3s/templates/rbac/clusterrole.yaml
+++ b/charts/k3s/templates/rbac/clusterrole.yaml
@@ -18,9 +18,12 @@ rules:
     resources: ["nodes", "nodes/status"]
     verbs: ["get", "watch", "list"]
   - apiGroups: [""]
-    resources: resources: [ "pods",{{- if .Values.isolation.enabled }}
-      {{- if .Values.isolation.nodeProxyPermission.enabled}} "node/proxy",{{- end}}
-      {{- else}} "node/proxy",{{- end }} "nodes/metrics", "nodes/stats"]
+    resources: [ "pods", "nodes/metrics", "nodes/stats"]
+    verbs: ["get", "watch", "list"]
+  {{- end }}
+  {{- if and (or .Values.sync.nodes.enabled .Values.rbac.clusterRole.create) (or (not .Values.isolation.enabled) (and .Values.isolation.nodeProxyPermission.enabled .Values.isolation.enabled)) }}
+  - apiGroups: [""]
+    resources: ["nodes/proxy"]
     verbs: ["get", "watch", "list"]
   {{- end }}
   {{- if or (and .Values.sync.nodes.enabled .Values.sync.nodes.syncNodeChanges) .Values.rbac.clusterRole.create }}

--- a/charts/k3s/templates/rbac/clusterrole.yaml
+++ b/charts/k3s/templates/rbac/clusterrole.yaml
@@ -18,7 +18,9 @@ rules:
     resources: ["nodes", "nodes/status"]
     verbs: ["get", "watch", "list"]
   - apiGroups: [""]
-    resources: ["pods", "nodes/proxy", "nodes/metrics", "nodes/stats"]
+    resources: resources: [ "pods",{{- if .Values.isolation.enabled }}
+      {{- if .Values.isolation.nodeProxyPermission.enabled}} "node/proxy",{{- end}}
+      {{- else}} "node/proxy",{{- end }} "nodes/metrics", "nodes/stats"]
     verbs: ["get", "watch", "list"]
   {{- end }}
   {{- if or (and .Values.sync.nodes.enabled .Values.sync.nodes.syncNodeChanges) .Values.rbac.clusterRole.create }}

--- a/charts/k3s/values.yaml
+++ b/charts/k3s/values.yaml
@@ -358,6 +358,11 @@ isolation:
 
   podSecurityStandard: baseline
 
+  # If enabled will add node/proxy permission to the cluster role
+  # in isolation mode
+  nodeProxyPermission:
+    enabled: false
+
   resourceQuota:
     enabled: true
     quota:

--- a/charts/k8s/templates/rbac/clusterrole.yaml
+++ b/charts/k8s/templates/rbac/clusterrole.yaml
@@ -18,7 +18,9 @@ rules:
     resources: ["nodes", "nodes/status"]
     verbs: ["get", "watch", "list"]
   - apiGroups: [""]
-    resources: ["pods", "nodes/proxy", "nodes/metrics", "nodes/stats"]
+    resources: [ "pods",{{- if .Values.isolation.enabled }}
+      {{- if .Values.isolation.nodeProxyPermission.enabled}} "node/proxy",{{- end}}
+      {{- else}} "node/proxy",{{- end }} "nodes/metrics", "nodes/stats"]
     verbs: ["get", "watch", "list"]
   {{- end }}
   {{- if or (and .Values.sync.nodes.enabled .Values.sync.nodes.syncNodeChanges) .Values.rbac.clusterRole.create }}

--- a/charts/k8s/templates/rbac/clusterrole.yaml
+++ b/charts/k8s/templates/rbac/clusterrole.yaml
@@ -18,9 +18,12 @@ rules:
     resources: ["nodes", "nodes/status"]
     verbs: ["get", "watch", "list"]
   - apiGroups: [""]
-    resources: [ "pods",{{- if .Values.isolation.enabled }}
-      {{- if .Values.isolation.nodeProxyPermission.enabled}} "node/proxy",{{- end}}
-      {{- else}} "node/proxy",{{- end }} "nodes/metrics", "nodes/stats"]
+    resources: [ "pods", "nodes/metrics", "nodes/stats"]
+    verbs: ["get", "watch", "list"]
+  {{- end }}
+  {{- if and (or .Values.sync.nodes.enabled .Values.rbac.clusterRole.create) (or (not .Values.isolation.enabled) (and .Values.isolation.nodeProxyPermission.enabled .Values.isolation.enabled)) }}
+  - apiGroups: [""]
+    resources: ["nodes/proxy"]
     verbs: ["get", "watch", "list"]
   {{- end }}
   {{- if or (and .Values.sync.nodes.enabled .Values.sync.nodes.syncNodeChanges) .Values.rbac.clusterRole.create }}

--- a/charts/k8s/values.yaml
+++ b/charts/k8s/values.yaml
@@ -403,6 +403,11 @@ isolation:
 
   podSecurityStandard: baseline
 
+  # If enabled will add node/proxy permission to the cluster role
+  # in isolation mode
+  nodeProxyPermission:
+    enabled: false
+
   resourceQuota:
     enabled: true
     quota:

--- a/test/e2e_isolation_mode/values.yaml
+++ b/test/e2e_isolation_mode/values.yaml
@@ -1,5 +1,7 @@
 isolation:
   enabled: true
+  nodeProxyPermission:
+    enabled: true
   resourceQuota:
     quota:
       services.nodeports: 3


### PR DESCRIPTION
Remove the node/proxy permission from the cluster role when isolated mode is enabled. 
Add a new Helm value to optionally allow original behavior even in the isolated mode.

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind feature

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves 937


**Please provide a short message that should be published in the vcluster release notes**
Remove the node/proxy permission from the cluster role when isolated mode is enabled. 
Add a new Helm value to optionally allow original behavior even in the isolated mode.


**What else do we need to know?** 
