### PR TITLE
Fix statefulset broken tamplate

### DIFF
--- a/charts/eks/templates/etcd-statefulset.yaml
+++ b/charts/eks/templates/etcd-statefulset.yaml
@@ -33,7 +33,11 @@ spec:
         name: data
       spec:
         accessModes: [ "ReadWriteOnce" ]
+        {{- if .Values.etcd.storage.className }}
         storageClassName: {{ .Values.etcd.storage.className }}
+        {{- else }}
+        storageClassName: ""
+        {{- end }}
         resources:
           requests:
             storage: {{ .Values.etcd.storage.size }}

--- a/charts/eks/templates/etcd-statefulset.yaml
+++ b/charts/eks/templates/etcd-statefulset.yaml
@@ -35,8 +35,6 @@ spec:
         accessModes: [ "ReadWriteOnce" ]
         {{- if .Values.etcd.storage.className }}
         storageClassName: {{ .Values.etcd.storage.className }}
-        {{- else }}
-        storageClassName: ""
         {{- end }}
         resources:
           requests:

--- a/charts/k0s/templates/statefulset.yaml
+++ b/charts/k0s/templates/statefulset.yaml
@@ -33,8 +33,6 @@ spec:
         accessModes: [ "ReadWriteOnce" ]
         {{- if .Values.storage.className }}
         storageClassName: {{ .Values.storage.className }}
-        {{- else }}
-        storageClassName: ""
         {{- end }}
         resources:
           requests:

--- a/charts/k0s/templates/statefulset.yaml
+++ b/charts/k0s/templates/statefulset.yaml
@@ -31,7 +31,11 @@ spec:
         name: data
       spec:
         accessModes: [ "ReadWriteOnce" ]
+        {{- if .Values.storage.className }}
         storageClassName: {{ .Values.storage.className }}
+        {{- else }}
+        storageClassName: ""
+        {{- end }}
         resources:
           requests:
             storage: {{ .Values.storage.size }}

--- a/charts/k3s/templates/statefulset.yaml
+++ b/charts/k3s/templates/statefulset.yaml
@@ -49,8 +49,6 @@ spec:
         accessModes: [ "ReadWriteOnce" ]
         {{- if .Values.storage.className }}
         storageClassName: {{ .Values.storage.className }}
-        {{- else }}
-        storageClassName: ""
         {{- end }}
         resources:
           requests:

--- a/charts/k3s/templates/statefulset.yaml
+++ b/charts/k3s/templates/statefulset.yaml
@@ -47,7 +47,11 @@ spec:
         name: data
       spec:
         accessModes: [ "ReadWriteOnce" ]
+        {{- if .Values.storage.className }}
         storageClassName: {{ .Values.storage.className }}
+        {{- else }}
+        storageClassName: ""
+        {{- end }}
         resources:
           requests:
             storage: {{ .Values.storage.size }}

--- a/charts/k8s/templates/etcd-statefulset.yaml
+++ b/charts/k8s/templates/etcd-statefulset.yaml
@@ -33,7 +33,11 @@ spec:
         name: data
       spec:
         accessModes: [ "ReadWriteOnce" ]
+        {{- if .Values.etcd.storage.className}}
         storageClassName: {{ .Values.etcd.storage.className }}
+        {{- else }}
+        storageClassName: ""
+        {{- end }}
         resources:
           requests:
             storage: {{ .Values.etcd.storage.size }}

--- a/charts/k8s/templates/etcd-statefulset.yaml
+++ b/charts/k8s/templates/etcd-statefulset.yaml
@@ -35,8 +35,6 @@ spec:
         accessModes: [ "ReadWriteOnce" ]
         {{- if .Values.etcd.storage.className}}
         storageClassName: {{ .Values.etcd.storage.className }}
-        {{- else }}
-        storageClassName: ""
         {{- end }}
         resources:
           requests:


### PR DESCRIPTION
Added condition in helm template to check storageClassName field values is null or not. If field value is set to null then storageClassName value is set to empty string which use default storage class

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement


**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster helm storageClass template is passing nil value to storageClassName field if className is not set/passed in the values.yaml

**What else do we need to know?** 
