### PR TITLE
bugfix: set labels to kubeconfig and cert secrets

### DIFF
--- a/pkg/certs/ensure.go
+++ b/pkg/certs/ensure.go
@@ -22,6 +22,12 @@ import (
 	"k8s.io/klog/v2"
 )
 
+const (
+	CertSecretLabelAppKey          = "app"
+	CertSecretLabelAppValue        = "vcluster"
+	CertSecretLabelVclusterNameKey = "vcluster-name"
+)
+
 func EnsureCerts(
 	ctx context.Context,
 	serviceCIDR string,
@@ -131,6 +137,10 @@ func EnsureCerts(
 			Name:            secretName,
 			Namespace:       currentNamespace,
 			OwnerReferences: ownerRef,
+			Labels: map[string]string{
+				CertSecretLabelAppKey:          CertSecretLabelAppValue,
+				CertSecretLabelVclusterNameKey: options.Name,
+			},
 		},
 		Data: map[string][]byte{},
 	}

--- a/pkg/setup/controllers.go
+++ b/pkg/setup/controllers.go
@@ -265,14 +265,14 @@ func WriteKubeConfigToSecret(ctx context.Context, virtualConfig *rest.Config, cu
 		}
 
 		// Use customSyncerConfig for the additional secret if it was modified, else syncerConfig
-		err = kubeconfig.WriteKubeConfig(ctx, currentNamespaceClient, options.ExportKubeConfig.Secret.Name, secretNamespace, customSyncerConfig, options.Experimental.IsolatedControlPlane.KubeConfig != "")
+		err = kubeconfig.WriteKubeConfig(ctx, currentNamespaceClient, options.ExportKubeConfig.Secret.Name, secretNamespace, customSyncerConfig, options.Experimental.IsolatedControlPlane.KubeConfig != "", options.Name)
 		if err != nil {
 			return fmt.Errorf("creating %s secret in the %s ns failed: %w", options.ExportKubeConfig.Secret.Name, secretNamespace, err)
 		}
 	}
 
 	// Write the default secret using syncerConfig, which retains the original Server value
-	return kubeconfig.WriteKubeConfig(ctx, currentNamespaceClient, kubeconfig.GetDefaultSecretName(translate.VClusterName), currentNamespace, syncerConfig, options.Experimental.IsolatedControlPlane.KubeConfig != "")
+	return kubeconfig.WriteKubeConfig(ctx, currentNamespaceClient, kubeconfig.GetDefaultSecretName(translate.VClusterName), currentNamespace, syncerConfig, options.Experimental.IsolatedControlPlane.KubeConfig != "", options.Name)
 }
 
 // applyAuthToken sets the provided token in all AuthInfos of the given config

--- a/pkg/util/kubeconfig/kubeconfig.go
+++ b/pkg/util/kubeconfig/kubeconfig.go
@@ -26,15 +26,18 @@ import (
 )
 
 const (
-	DefaultSecretPrefix     = "vc-"
-	KubeconfigSecretKey     = "config"
-	CADataSecretKey         = "certificate-authority"
-	CertificateSecretKey    = "client-certificate"
-	CertificateKeySecretKey = "client-key"
-	TokenSecretKey          = "token"
+	DefaultSecretPrefix             = "vc-"
+	KubeconfigSecretKey             = "config"
+	CADataSecretKey                 = "certificate-authority"
+	CertificateSecretKey            = "client-certificate"
+	CertificateKeySecretKey         = "client-key"
+	TokenSecretKey                  = "token"
+	KubeConfigSecretLabelAppKey     = "app"
+	KubeConfigSecretLabelAppValue   = "vcluster"
+	KubeConfigSecretVclusterNameKey = "vcluster-name"
 )
 
-func WriteKubeConfig(ctx context.Context, currentNamespaceClient client.Client, secretName, secretNamespace string, config *clientcmdapi.Config, isRemote bool) error {
+func WriteKubeConfig(ctx context.Context, currentNamespaceClient client.Client, secretName, secretNamespace string, config *clientcmdapi.Config, isRemote bool, vClusterName string) error {
 	out, err := clientcmd.Write(*config)
 	if err != nil {
 		return err
@@ -70,6 +73,10 @@ func WriteKubeConfig(ctx context.Context, currentNamespaceClient client.Client, 
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      secretName,
 				Namespace: secretNamespace,
+				Labels: map[string]string{
+					KubeConfigSecretLabelAppKey:     KubeConfigSecretLabelAppValue,
+					KubeConfigSecretVclusterNameKey: vClusterName,
+				},
 			},
 		}
 		result, err := controllerutil.CreateOrPatch(ctx, currentNamespaceClient, kubeConfigSecret, func() error {


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
The pull request adds labels to two secrets that contain a kubeconfig and a certificate. These labels help improve the organization and management of the secrets.


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vcluster 2 secrets containing a kubeconfig and a certificate were missing labels.


**What else do we need to know?** 
