### PR TITLE
bugfix: set cluster-ip when mapping host to vCluster service

### DIFF
--- a/pkg/controllers/servicesync/servicesync.go
+++ b/pkg/controllers/servicesync/servicesync.go
@@ -219,9 +219,15 @@ func (e *ServiceSyncer) syncServiceAndEndpoints(ctx context.Context, fromService
 				},
 			},
 			Spec: corev1.ServiceSpec{
-				Ports:     fromService.Spec.Ports,
-				ClusterIP: corev1.ClusterIPNone,
+				Ports: fromService.Spec.Ports,
 			},
+		}
+
+		// Check if ClusterIP is not "None"
+		if fromService.Spec.ClusterIP != corev1.ClusterIPNone {
+			toService.Spec.ClusterIP = fromService.Spec.ClusterIP
+		} else {
+			toService.Spec.ClusterIP = corev1.ClusterIPNone
 		}
 
 		if e.IsVirtualToHostSyncer {

--- a/test/e2e/servicesync/servicesync.go
+++ b/test/e2e/servicesync/servicesync.go
@@ -163,6 +163,7 @@ func testMapping(ctx context.Context, fromClient kubernetes.Interface, fromNames
 		framework.ExpectEqual(toService.Spec.Selector[translate.NamespaceLabel], fromNamespace)
 		framework.ExpectEqual(toService.Spec.Selector[translate.MarkerLabel], translate.VClusterName)
 		framework.ExpectEqual(toService.Spec.Selector[translate.HostLabel("test")], "test")
+		framework.ExpectEqual(toService.Spec.ClusterIP, fromService.Spec.ClusterIP)
 	}
 
 	// check service deletion


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
This pull request ensures that the Service cluster-ip is correctly set when mapping the host cluster service to the vCluster service.


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue where vCluster service mapping resulted in the Service cluster-ip being set to none.


**What else do we need to know?** 
The service was initially appearing as a headless service due to the cluster-ip being displayed as none in the vCluster. In reality, the cluster-ip of the service in the host cluster was being correctly used in the endpoints created within the vCluster. The endpoints in the virtual cluster were pointing to the host cluster's cluster-ip, and despite the none display in the vCluster service, the traffic was correctly routed when the service in the vCluster was used.